### PR TITLE
feature/add-interface-parameter-mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ It is built using React, TypeScript, Vite and React Leaflet.
 - Draw geometries
 - Choose interface
 - Choose topic(s)
-- Selection fields for interface and topics depend on each other
 - Set parameters
+- Selection fields for interface, topics and parameters depend on each other
 - Make an API call
 - Show response
 - Show returned geometry in map
@@ -24,8 +24,7 @@ It is built using React, TypeScript, Vite and React Leaflet.
 ### To do
 
 - Improve geometry handling
-- Send all drawn geometries to API
-- Add more interfaces and parameters
+- Send more than one geometry to API
 - Make it mobile friendly
 - Fine-tuning in general
 - Update topics when GA is ready

--- a/src/App.css
+++ b/src/App.css
@@ -23,6 +23,15 @@ select {
   width: 100%;
 }
 
+#count,
+#maxDistanceToNeighbour {
+  width: 6em;
+}
+
+.lbl--parameter {
+  margin-left: 5px;
+}
+
 .btn--send-geometry {
   width: 100%;
 }


### PR DESCRIPTION
This pull request introduces an interface-parameter-mapping feature, which ensures that for each interface, the valid parameter options are displayed in the user interface.

As a result, the nearestNeighbour interface is now usable.

It fixes the following issues:

Fixes #1 
Fixes #2 