### PR TITLE
chore(deps): add ci workflow and renovate config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+
+      - name: Install pnpm
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Build
+        run: pnpm run build

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests"
+  ],
+  "packageRules": [
+    {
+      "description": "React ecosystem",
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom", "@vitejs/plugin-react"],
+      "groupName": "react"
+    },
+    {
+      "description": "Leaflet ecosystem",
+      "matchPackageNames": ["leaflet", "leaflet-draw", "react-leaflet", "react-leaflet-draw", "@types/leaflet", "@types/leaflet-draw"],
+      "groupName": "leaflet"
+    },
+    {
+      "description": "ESLint and TypeScript tooling",
+      "matchPackageNames": ["eslint", "@eslint/js", "typescript", "typescript-eslint", "@typescript-eslint/**", "eslint-plugin-*"],
+      "groupName": "linting-and-typescript"
+    },
+    {
+      "description": "Automerge patch updates when CI passes",
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
- Add GitHub Actions CI pipeline (lint + build) on push/PR to `main`
- Add Renovate config with ecosystem grouping and patch automerge
- Add `engines.node: "24"` to `package.json` for consistent Node version across CI and Renovate
