### PR TITLE
feat(map): show feature attributes in popups

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -82,3 +82,81 @@ select {
 .sr-only {
   display: none;
 }
+
+/* Popup with feature attributes */
+.popup-properties {
+  font-size: 0.85em;
+  line-height: 1.2;
+  max-width: 340px;
+  overflow-wrap: anywhere;
+  color: #1f2937;
+}
+
+.popup-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.popup-table th,
+.popup-table td {
+  text-align: left;
+  vertical-align: top;
+  padding: 5px 10px 5px 0;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.popup-properties > .popup-table > tbody > tr > td {
+  width: 100%;
+}
+
+.popup-table tr:last-child > th,
+.popup-table tr:last-child > td {
+  border-bottom: none;
+}
+
+.popup-table th {
+  font-weight: 600;
+  white-space: nowrap;
+  color: #475569;
+  letter-spacing: 0.01em;
+}
+
+/* Visually distinguish nested tables */
+.popup-table .popup-table {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 4px;
+}
+
+.popup-table .popup-table th,
+.popup-table .popup-table td {
+  padding: 3px 8px;
+  font-size: 0.95em;
+  border-bottom-color: rgba(15, 23, 42, 0.05);
+}
+
+.popup-list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.popup-list > li + li {
+  margin-top: 4px;
+}
+
+.popup-empty {
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.popup-properties a {
+  color: #2563eb;
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  word-break: break-all;
+}
+
+.popup-properties a:hover {
+  color: #1d4ed8;
+}

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,13 +1,20 @@
-import React, { useRef, useEffect } from 'react';
-import { MapContainer, TileLayer, FeatureGroup, Polygon } from 'react-leaflet';
+import React, { useRef } from 'react';
+import {
+  MapContainer,
+  TileLayer,
+  FeatureGroup,
+  Polygon,
+  GeoJSON,
+} from 'react-leaflet';
 import L, { DrawEvents, LatLngExpression } from 'leaflet';
 import { EditControl } from 'react-leaflet-draw';
-import { Feature, Geometry } from 'geojson';
+import { Feature, FeatureCollection, Geometry } from 'geojson';
 import {
   BOUNDING_BOX,
   TILE_LAYER_URL,
   TILE_LAYER_ATTRIBUTION,
 } from '../config/config';
+import { propertiesToElement } from '../utils/popup';
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-draw/dist/leaflet.draw.css';
 
@@ -76,21 +83,6 @@ const Map: React.FC<MapProps> = ({
     clearGeometries();
   };
 
-  useEffect(() => {
-    if (featureGroupRef.current) {
-      //featureGroupRef.current.clearLayers();
-      //[...userGeometries, ...apiGeometries].forEach((geometry) => {
-      [...apiGeometries].forEach((geometry) => {
-        const layer = L.geoJSON(geometry, {
-          style: { color: 'coral' },
-        });
-        layer.addTo(featureGroupRef.current!);
-        console.log('Returned geometry added to map:', geometry);
-      });
-    }
-    //  }, [userGeometries, apiGeometries]);
-  }, [apiGeometries]);
-
   const convertToLatLng = (positions: number[][]): LatLngExpression[] => {
     return positions.map((position) => {
       return [position[0], position[1]] as LatLngExpression;
@@ -98,6 +90,18 @@ const Map: React.FC<MapProps> = ({
   };
 
   const polygonPositions: LatLngExpression[] = convertToLatLng(BOUNDING_BOX);
+
+  const apiFeatureCollection: FeatureCollection = {
+    type: 'FeatureCollection',
+    features: apiGeometries,
+  };
+
+  const onEachApiFeature = (feature: Feature, layer: L.Layer) => {
+    layer.bindPopup(propertiesToElement(feature.properties), {
+      maxWidth: 360,
+      maxHeight: 360,
+    });
+  };
 
   return (
     <div className="map-container">
@@ -112,6 +116,12 @@ const Map: React.FC<MapProps> = ({
           positions={polygonPositions}
           color="gray"
           fillColor="transparent"
+        />
+        <GeoJSON
+          key={apiGeometries.length}
+          data={apiFeatureCollection}
+          style={{ color: 'coral' }}
+          onEachFeature={onEachApiFeature}
         />
         <FeatureGroup ref={featureGroupRef}>
           <EditControl

--- a/src/utils/popup.ts
+++ b/src/utils/popup.ts
@@ -1,0 +1,85 @@
+import type { GeoJsonProperties } from 'geojson';
+
+// CVE-2025-69993: Leaflet v1.9.4 bindPopup is prone to Cross-Site-Scripting (XSS) when given HTML strings.
+// Build the DOM via createElement/textContent so no value ever reaches innerHTML.
+const URL_PATTERN = /^https?:\/\//i;
+
+const emptyNode = (text: string): HTMLElement => {
+  const span = document.createElement('span');
+  span.className = 'popup-empty';
+  span.textContent = text;
+  return span;
+};
+
+const objectToTable = (obj: Record<string, unknown>): HTMLElement => {
+  const entries = Object.entries(obj);
+  if (entries.length === 0) {
+    return emptyNode('{}');
+  }
+  const table = document.createElement('table');
+  table.className = 'popup-table';
+  const tbody = document.createElement('tbody');
+  for (const [key, value] of entries) {
+    const tr = document.createElement('tr');
+    const th = document.createElement('th');
+    th.textContent = key;
+    const td = document.createElement('td');
+    td.appendChild(valueToNode(value));
+    tr.appendChild(th);
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  return table;
+};
+
+const valueToNode = (value: unknown): Node => {
+  if (value === null || value === undefined) {
+    return emptyNode('—');
+  }
+  if (typeof value === 'string') {
+    if (URL_PATTERN.test(value)) {
+      const a = document.createElement('a');
+      a.href = value;
+      a.textContent = value;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      return a;
+    }
+    return document.createTextNode(value);
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return document.createTextNode(String(value));
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return emptyNode('[]');
+    }
+    const ul = document.createElement('ul');
+    ul.className = 'popup-list';
+    for (const item of value) {
+      const li = document.createElement('li');
+      li.appendChild(valueToNode(item));
+      ul.appendChild(li);
+    }
+    return ul;
+  }
+  if (typeof value === 'object') {
+    return objectToTable(value as Record<string, unknown>);
+  }
+  return document.createTextNode(String(value));
+};
+
+export const propertiesToElement = (
+  properties: GeoJsonProperties | null | undefined,
+): HTMLElement => {
+  const root = document.createElement('div');
+  root.className = 'popup-properties';
+  if (!properties || Object.keys(properties).length === 0) {
+    root.classList.add('popup-empty');
+    root.textContent = '(keine Attribute)';
+    return root;
+  }
+  root.appendChild(objectToTable(properties as Record<string, unknown>));
+  return root;
+};


### PR DESCRIPTION
## Summary
- Render feature properties as styled key/value table in popups (nested objects → sub-tables, URLs → links)
- Build DOM via `createElement`/`textContent` to avoid XSS (CVE-2025-69993)

## Test plan
- [x] Click feature → popup shows properties; long values wrap, URLs are clickable