### PR TITLE
feat(map): add viewport-aware bbox labels

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -160,3 +160,20 @@ select {
 .popup-properties a:hover {
   color: #1d4ed8;
 }
+
+/* Permanent label on the demo data bounding box */
+.leaflet-tooltip.bbox-label {
+  background: rgba(255, 255, 255, 0.7);
+  border: none;
+  box-shadow: none;
+  color: #6b7280;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  padding: 2px 6px;
+  pointer-events: none;
+}
+
+.leaflet-tooltip.bbox-label::before {
+  display: none;
+}

--- a/src/components/BboxLabels.tsx
+++ b/src/components/BboxLabels.tsx
@@ -1,0 +1,111 @@
+import React, { useState, useEffect } from 'react';
+import { Marker, Tooltip, useMap } from 'react-leaflet';
+import L, { LatLngExpression } from 'leaflet';
+import { BOUNDING_BOX } from '../config/config';
+
+const BBOX_LABEL_ICON = L.divIcon({
+  className: 'bbox-label-anchor',
+  iconSize: [0, 0],
+  iconAnchor: [0, 0],
+  html: '',
+});
+
+const BBOX_MIN_LAT = Math.min(...BOUNDING_BOX.map((p) => p[0]));
+const BBOX_MAX_LAT = Math.max(...BOUNDING_BOX.map((p) => p[0]));
+const BBOX_MIN_LNG = Math.min(...BOUNDING_BOX.map((p) => p[1]));
+const BBOX_MAX_LNG = Math.max(...BOUNDING_BOX.map((p) => p[1]));
+
+type BboxLabelAnchor = {
+  key: 'n' | 's' | 'w' | 'e';
+  position: LatLngExpression;
+  direction: 'top' | 'bottom' | 'left' | 'right';
+};
+
+const computeVisibleBboxAnchors = (map: L.Map): BboxLabelAnchor[] => {
+  const bounds = map.getBounds();
+  const vMinLat = bounds.getSouth();
+  const vMaxLat = bounds.getNorth();
+  const vMinLng = bounds.getWest();
+  const vMaxLng = bounds.getEast();
+
+  const lngLo = Math.max(BBOX_MIN_LNG, vMinLng);
+  const lngHi = Math.min(BBOX_MAX_LNG, vMaxLng);
+  const latLo = Math.max(BBOX_MIN_LAT, vMinLat);
+  const latHi = Math.min(BBOX_MAX_LAT, vMaxLat);
+
+  const horizontalVisible = lngLo < lngHi;
+  const verticalVisible = latLo < latHi;
+  const lngMid = (lngLo + lngHi) / 2;
+  const latMid = (latLo + latHi) / 2;
+
+  const anchors: BboxLabelAnchor[] = [];
+  if (horizontalVisible && BBOX_MAX_LAT >= vMinLat && BBOX_MAX_LAT <= vMaxLat) {
+    anchors.push({
+      key: 'n',
+      position: [BBOX_MAX_LAT, lngMid],
+      direction: 'top',
+    });
+  }
+  if (horizontalVisible && BBOX_MIN_LAT >= vMinLat && BBOX_MIN_LAT <= vMaxLat) {
+    anchors.push({
+      key: 's',
+      position: [BBOX_MIN_LAT, lngMid],
+      direction: 'bottom',
+    });
+  }
+  if (verticalVisible && BBOX_MIN_LNG >= vMinLng && BBOX_MIN_LNG <= vMaxLng) {
+    anchors.push({
+      key: 'w',
+      position: [latMid, BBOX_MIN_LNG],
+      direction: 'left',
+    });
+  }
+  if (verticalVisible && BBOX_MAX_LNG >= vMinLng && BBOX_MAX_LNG <= vMaxLng) {
+    anchors.push({
+      key: 'e',
+      position: [latMid, BBOX_MAX_LNG],
+      direction: 'right',
+    });
+  }
+  return anchors;
+};
+
+const BboxLabels: React.FC = () => {
+  const map = useMap();
+  const [anchors, setAnchors] = useState<BboxLabelAnchor[]>(() =>
+    computeVisibleBboxAnchors(map),
+  );
+
+  useEffect(() => {
+    const update = () => setAnchors(computeVisibleBboxAnchors(map));
+    map.on('move', update);
+    map.on('zoom', update);
+    return () => {
+      map.off('move', update);
+      map.off('zoom', update);
+    };
+  }, [map]);
+
+  return (
+    <>
+      {anchors.map((anchor) => (
+        <Marker
+          key={anchor.key}
+          position={anchor.position}
+          icon={BBOX_LABEL_ICON}
+          interactive={false}
+        >
+          <Tooltip
+            permanent
+            direction={anchor.direction}
+            className="bbox-label"
+          >
+            Demo Data Bounding Box
+          </Tooltip>
+        </Marker>
+      ))}
+    </>
+  );
+};
+
+export default BboxLabels;

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -15,6 +15,7 @@ import {
   TILE_LAYER_ATTRIBUTION,
 } from '../config/config';
 import { propertiesToElement } from '../utils/popup';
+import BboxLabels from './BboxLabels';
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-draw/dist/leaflet.draw.css';
 
@@ -69,7 +70,6 @@ const Map: React.FC<MapProps> = ({
   const onCreated = (e: CreatedEvent) => {
     const { layer } = e;
 
-    // Check that the layer is a FeatureLayer that has the toGeoJSON method
     if ('toGeoJSON' in layer && typeof layer.toGeoJSON === 'function') {
       const geoJson = (layer as L.FeatureGroup).toGeoJSON();
       console.log('Created geometry:', geoJson);
@@ -112,11 +112,8 @@ const Map: React.FC<MapProps> = ({
         style={{ height: '100%', width: '100%' }}
       >
         <TileLayer attribution={TILE_LAYER_ATTRIBUTION} url={TILE_LAYER_URL} />
-        <Polygon
-          positions={polygonPositions}
-          color="gray"
-          fillColor="transparent"
-        />
+        <Polygon positions={polygonPositions} color="gray" fill={false} />
+        <BboxLabels />
         <GeoJSON
           key={apiGeometries.length}
           data={apiFeatureCollection}


### PR DESCRIPTION
- Show permanent "Demo Data Bounding Box" tooltip labels on the visible edges of the bounding box polygon, updating on map move and zoom.
- Also replace `fillColor="transparent"` with `fill={false}` on the polygon. This eliminates the unintended pointer cursor on hover.