### PR TITLE
feat(map): make bbox overlay opt-in via VITE_SHOW_BBOX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 VITE_API_URL=your_api_url # For example: http://localhost/v1
+VITE_SHOW_BBOX=true # set to false (or omit) to hide the demo-data bounding box

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,11 @@ RUN corepack enable && pnpm install --frozen-lockfile
 
 COPY . .
 
-# Build argument for API URL with default value
+# Build args (override at build time, e.g. --build-arg VITE_SHOW_BBOX=true)
 ARG VITE_API_URL="http://localhost:3000/v1"
+ARG VITE_SHOW_BBOX=false
 
-RUN pnpm run build
+RUN VITE_API_URL=$VITE_API_URL VITE_SHOW_BBOX=$VITE_SHOW_BBOX pnpm run build
 
 FROM nginx:alpine-slim
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,5 +1,6 @@
 interface ImportMetaEnv {
   VITE_API_URL: string;
+  VITE_SHOW_BBOX?: string;
 }
 
 interface ImportMeta {

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -11,6 +11,7 @@ import { EditControl } from 'react-leaflet-draw';
 import { Feature, FeatureCollection, Geometry } from 'geojson';
 import {
   BOUNDING_BOX,
+  SHOW_BBOX,
   TILE_LAYER_URL,
   TILE_LAYER_ATTRIBUTION,
 } from '../config/config';
@@ -112,8 +113,10 @@ const Map: React.FC<MapProps> = ({
         style={{ height: '100%', width: '100%' }}
       >
         <TileLayer attribution={TILE_LAYER_ATTRIBUTION} url={TILE_LAYER_URL} />
-        <Polygon positions={polygonPositions} color="gray" fill={false} />
-        <BboxLabels />
+        {SHOW_BBOX && (
+          <Polygon positions={polygonPositions} color="gray" fill={false} />
+        )}
+        {SHOW_BBOX && <BboxLabels />}
         <GeoJSON
           key={apiGeometries.length}
           data={apiFeatureCollection}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -95,6 +95,9 @@ export const TOPICS: Record<string, { interfaces: string[]; label?: string }> =
 export const INITIAL_POSITION: [number, number] = [51.009504, 13.806652];
 export const INITIAL_ZOOM = 13;
 
+// Show the bbox overlay (only useful when running GeospatialAnalyzer with the demo data)
+export const SHOW_BBOX: boolean = import.meta.env.VITE_SHOW_BBOX === 'true';
+
 // Bounding box polygon shown in the map
 export const BOUNDING_BOX: number[][] = [
   [50.952162, 13.666581],


### PR DESCRIPTION
## Summary
- Gate the demo-data bbox overlay behind `VITE_SHOW_BBOX` (default `false`)
- Prod builds ship without it; set `true` in `.env` for running GeospatialAnalyzer with the demo data
## Test plan
- [x] `pnpm build` + `podman build --build-arg VITE_SHOW_BBOX=true` → overlay in bundle
- [x] `podman build` (default) → overlay tree-shaken out