### PR TITLE
feat(map): add control to clear only API responses

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -83,6 +83,41 @@ select {
   display: none;
 }
 
+/* Custom "Clear Responses" toolbar button (mirrors leaflet-draw button style) */
+.clear-responses-control {
+  position: relative;
+}
+
+.clear-responses-control a,
+.clear-responses-control a:link,
+.clear-responses-control a:visited,
+.clear-responses-control a:hover,
+.clear-responses-control a:active,
+.clear-responses-control a:focus {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  font-size: 18px;
+  line-height: 1;
+  color: #464646;
+  text-decoration: none;
+}
+
+.clear-responses-control a::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: coral;
+  box-shadow: 0 0 0 1px #fff;
+  pointer-events: none;
+}
+
 /* Popup with feature attributes */
 .popup-properties {
   font-size: 0.85em;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,10 @@ const App: React.FC = () => {
     setApiGeometries([]);
   };
 
+  const clearApiGeometries = () => {
+    setApiGeometries([]);
+  };
+
   return (
     <div className="app-container">
       <Map
@@ -35,6 +39,7 @@ const App: React.FC = () => {
         setUserGeometries={addUserGeometries}
         apiGeometries={apiGeometries}
         clearGeometries={clearGeometries}
+        clearApiGeometries={clearApiGeometries}
       />
       <APICall
         userGeometries={userGeometries}

--- a/src/components/ClearResponsesControl.tsx
+++ b/src/components/ClearResponsesControl.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useRef } from 'react';
+import { useMap } from 'react-leaflet';
+import L from 'leaflet';
+
+interface ClearResponsesControlProps {
+  onClear: () => void;
+}
+
+const ClearResponsesControl: React.FC<ClearResponsesControlProps> = ({
+  onClear,
+}) => {
+  const map = useMap();
+  const onClearRef = useRef(onClear);
+
+  useEffect(() => {
+    onClearRef.current = onClear;
+  }, [onClear]);
+
+  useEffect(() => {
+    const ControlClass = L.Control.extend({
+      onAdd: () => {
+        const container = L.DomUtil.create(
+          'div',
+          'leaflet-bar leaflet-control clear-responses-control',
+        );
+        const link = L.DomUtil.create('a', '', container);
+        link.href = '#';
+        link.title = 'Clear Responses';
+        link.setAttribute('role', 'button');
+        link.setAttribute('aria-label', 'Clear Responses');
+        link.textContent = '↺';
+
+        L.DomEvent.disableClickPropagation(container);
+        L.DomEvent.on(link, 'click', (event) => {
+          L.DomEvent.preventDefault(event);
+          L.DomEvent.stopPropagation(event);
+          onClearRef.current();
+        });
+
+        return container;
+      },
+    });
+
+    const control = new ControlClass({ position: 'topright' });
+    control.addTo(map);
+
+    const moveToBottom = () => {
+      const el = control.getContainer();
+      const parent = el?.parentElement;
+      if (el && parent && parent.lastElementChild !== el) {
+        parent.appendChild(el);
+      }
+    };
+
+    const parent = control.getContainer()?.parentElement ?? null;
+    const observer = parent ? new MutationObserver(moveToBottom) : null;
+    observer?.observe(parent!, { childList: true });
+
+    return () => {
+      observer?.disconnect();
+      control.remove();
+    };
+  }, [map]);
+
+  return null;
+};
+
+export default ClearResponsesControl;

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -17,6 +17,7 @@ import {
 } from '../config/config';
 import { propertiesToElement } from '../utils/popup';
 import BboxLabels from './BboxLabels';
+import ClearResponsesControl from './ClearResponsesControl';
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-draw/dist/leaflet.draw.css';
 
@@ -39,6 +40,7 @@ interface MapProps {
   userGeometries: Feature<Geometry>[];
   apiGeometries: Feature<Geometry>[];
   clearGeometries: () => void;
+  clearApiGeometries: () => void;
 }
 
 const Map: React.FC<MapProps> = ({
@@ -48,6 +50,7 @@ const Map: React.FC<MapProps> = ({
   userGeometries,
   apiGeometries,
   clearGeometries,
+  clearApiGeometries,
 }) => {
   const featureGroupRef = useRef<L.FeatureGroup>(null);
 
@@ -123,6 +126,9 @@ const Map: React.FC<MapProps> = ({
           style={{ color: 'coral' }}
           onEachFeature={onEachApiFeature}
         />
+        {apiGeometries.length > 0 && (
+          <ClearResponsesControl onClear={clearApiGeometries} />
+        )}
         <FeatureGroup ref={featureGroupRef}>
           <EditControl
             position="topright"


### PR DESCRIPTION
## Summary
- New map control that clears only API response geometries (`apiGeometries`) while keeping drawn shapes
- Enables running multiple consecutive queries against the same input geometry without redrawing
- Only visible when responses exist; sits below the leaflet-draw toolbar with a coral dot indicating its link to the coral-styled response layer

## Test plan
- [x] Draw a polygon → send query → coral response appears, new ↺ button shows up below the draw toolbar
- [x] Click the ↺ button → only the response disappears, the drawn polygon remains
- [x] Send another query without redrawing → fresh response is rendered
- [x] Drawing additional geometries does not push the ↺ button up in the toolbar