### PR TITLE
feat(topics): load topics dynamically from the API with configurable URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=your_api_url # For example: http://localhost/v1
-VITE_SHOW_BBOX=true # set to false (or omit) to hide the demo-data bounding box
+VITE_API_URL=your_api_url # Base URL incl. version, e.g. http://localhost/ga/v2
+VITE_SHOW_BBOX=true # Set to false (or omit) to hide the demo-data bounding box

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ It is built using React, TypeScript, Vite and React Leaflet.
 
 ### Features
 
+- Load available topics dynamically from the API
+- Override the API URL at runtime
 - Draw geometries
 - Choose interface
 - Choose topic(s)
@@ -17,15 +19,15 @@ It is built using React, TypeScript, Vite and React Leaflet.
 - Make an API call
 - Show response
 - Show returned geometry in map
-- Config file for topics and other settings
+- Config file for the bounding box and other settings
 - Show the bounding box (hardcoded) from the sample data
 - Docker/Podman deployment
 
 ## Configuration
 
-Before running the application, you need to create a `.env` file to configure your environment variables. You can use the provided `.env.example` file as a template.
+Before running the application, you need to create a `.env` file to configure your environment variables. You can use the provided `.env.example` file as a template. `VITE_API_URL` sets the API base URL (including the version segment). It can also be overridden at runtime via the input field in the UI.
 
-You can customize the topics, bounding box and other settings in `src/config/config.ts`.
+The available topics are loaded dynamically from the API. You can customize the bounding box and other settings in `src/config/config.ts`.
 
 Depending on the deployment environment, consider adjusting `port_in_redirect` in `default.conf`. Disable it when running behind a reverse proxy and enable it for direct access (e.g. during local development) so redirects include the port. This ensures that `/ga-client` is redirected correctly to `/ga-client/` in both cases.
 

--- a/src/App.css
+++ b/src/App.css
@@ -15,7 +15,10 @@
   padding: 20px;
   display: flex;
   flex-direction: column;
-  min-width: 240px;
+  /* Fixed width so the sidebar doesn't resize as its content changes. */
+  flex: 0 0 440px;
+  width: 440px;
+  box-sizing: border-box;
   max-height: 100vh;
   overflow: auto;
 }
@@ -26,6 +29,62 @@
 
 select {
   width: 100%;
+}
+
+/* Topic multi-select: compact by default and resizable with the mouse. */
+.topic-select {
+  min-height: 5em;
+  resize: vertical;
+  overflow-y: auto;
+}
+
+.topic-select option {
+  padding: 3px 6px;
+}
+
+.api-url-row {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+}
+
+input[name='apiUrl'] {
+  flex: 1 1 auto;
+  min-width: 0;
+  box-sizing: border-box;
+  border: 1px solid #b0b0b0;
+  border-radius: 3px;
+  transition: border-color 0.2s ease;
+}
+
+input.api-url-input--pending {
+  border-color: #e0a800;
+}
+
+input.api-url-input--success {
+  border-color: #2e7d32;
+}
+
+input.api-url-input--error {
+  border-color: #c0392b;
+}
+
+.btn--apply-api-url {
+  flex: 0 0 auto;
+  width: 2em;
+  padding: 0;
+  cursor: pointer;
+  font-size: 1.1em;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.api-url-error {
+  color: #c0392b;
+  font-size: 0.85em;
+  margin: 6px 0 0;
 }
 
 #count,
@@ -70,7 +129,8 @@ select {
 
   .sidebar {
     padding: 12px;
-    min-width: 0;
+    flex: none;
+    width: auto;
   }
 
   .sidebar-content {

--- a/src/components/APICall.tsx
+++ b/src/components/APICall.tsx
@@ -5,9 +5,10 @@ import {
   INTERFACE_PARAMETER_MAPPING,
   INTERFACE_DEFAULT_PARAMETERS,
   DEFAULT_INTERFACE,
-  TOPICS,
+  DEFAULT_API_URL,
 } from '../config/config';
-const apiUrl = import.meta.env.VITE_API_URL;
+import { Topic, TopicDefinitionOutside, toTopic } from '../utils/topics';
+import { normalizeApiUrl } from '../utils/apiUrl';
 
 interface APICallProps {
   userGeometries: Feature<Geometry>[];
@@ -19,6 +20,13 @@ const APICall: React.FC<APICallProps> = ({
   addApiGeometries,
 }) => {
   const [result, setResult] = useState('');
+  const [apiUrl, setApiUrl] = useState<string>(DEFAULT_API_URL);
+  const [apiUrlDraft, setApiUrlDraft] = useState<string>(DEFAULT_API_URL);
+  const [topics, setTopics] = useState<Topic[]>([]);
+  const [topicsError, setTopicsError] = useState<string | null>(null);
+  const [topicsStatus, setTopicsStatus] = useState<
+    'idle' | 'success' | 'error'
+  >('idle');
   const [selectedTopics, setSelectedTopics] = useState<string[]>([]);
   const [selectedInterface, setSelectedInterface] =
     useState<string>(DEFAULT_INTERFACE);
@@ -38,6 +46,46 @@ const APICall: React.FC<APICallProps> = ({
   useEffect(() => {
     setActiveParameters(INTERFACE_PARAMETER_MAPPING[selectedInterface] ?? []);
   }, [selectedInterface]);
+
+  // Load the available topics whenever the applied API URL changes. An
+  // AbortController makes sure a slower in-flight request can't overwrite the
+  // result of a newer one (last requested wins, not last resolved).
+  useEffect(() => {
+    const controller = new AbortController();
+
+    // apiUrl is only ever a fetch() target (never script/innerHTML), so a
+    // non-http scheme can't execute and no scheme check is needed.
+    fetch(`${apiUrl}/topics`, { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status} ${response.statusText}`);
+        }
+        return response.json();
+      })
+      .then((data: TopicDefinitionOutside[]) => {
+        setTopics(data.map(toTopic));
+        setTopicsError(null);
+        setTopicsStatus('success');
+      })
+      .catch((error) => {
+        if (error.name === 'AbortError') return; // superseded by a newer request
+        console.error('Failed to load topics', error);
+        setTopics([]);
+        setTopicsError(
+          `Failed to load topics: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        setTopicsStatus('error');
+      });
+
+    return () => controller.abort();
+  }, [apiUrl]);
+
+  // Apply the edited API URL: reset the topic selection and let the effect
+  // above reload the available topics from the new URL.
+  const applyApiUrl = () => {
+    setSelectedTopics([]);
+    setApiUrl(normalizeApiUrl(apiUrlDraft));
+  };
 
   // Change parameter state automaticly
   const handleParameterChange = (key: string, value: string | number) => {
@@ -70,9 +118,9 @@ const APICall: React.FC<APICallProps> = ({
     }
 
     // Filter topics
-    const filteredTopics = Object.keys(TOPICS).filter((topic) =>
-      TOPICS[topic].interfaces.includes(selectedValue),
-    );
+    const filteredTopics = topics
+      .filter((topic) => topic.interfaces.includes(selectedValue))
+      .map((topic) => topic.identifier);
     setSelectedTopics(
       selectedTopics.filter((topic) => filteredTopics.includes(topic)),
     );
@@ -156,13 +204,70 @@ const APICall: React.FC<APICallProps> = ({
   };
 
   // Get the list of topics that are valid for the selected interface
-  const availableTopics = Object.keys(TOPICS).filter((topic) =>
-    TOPICS[topic].interfaces.includes(selectedInterface),
+  const availableTopics = topics.filter((topic) =>
+    topic.interfaces.includes(selectedInterface),
   );
+
+  // While the typed URL differs from the applied one, show a "pending" state
+  const apiUrlStatus =
+    normalizeApiUrl(apiUrlDraft) !== apiUrl ? 'pending' : topicsStatus;
+  const apiUrlPending = apiUrlStatus === 'pending';
 
   return (
     <div className="sidebar">
       <h2>GeospatialAnalyzer API Call</h2>
+      <div className="sidebar-content">
+        <fieldset>
+          <legend>API URL</legend>
+          <div className="api-url-row">
+            <input
+              type="text"
+              name="apiUrl"
+              className={`api-url-input api-url-input--${apiUrlStatus}`}
+              value={apiUrlDraft}
+              onChange={(e) => setApiUrlDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') applyApiUrl();
+              }}
+            />
+            <button
+              type="button"
+              className="btn--apply-api-url"
+              onClick={applyApiUrl}
+              title={
+                apiUrlPending ? 'Apply URL and load topics' : 'Reload topics'
+              }
+              aria-label={
+                apiUrlPending ? 'Apply URL and load topics' : 'Reload topics'
+              }
+            >
+              <svg
+                viewBox="0 0 24 24"
+                width="16"
+                height="16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                {apiUrlPending ? (
+                  // Checkmark: confirm the typed URL and fetch topics from it
+                  <polyline points="20 6 9 17 4 12" />
+                ) : (
+                  // Reload: re-fetch topics from the unchanged URL
+                  <>
+                    <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+                    <polyline points="21 3 21 8 16 8" />
+                  </>
+                )}
+              </svg>
+            </button>
+          </div>
+          {topicsError && <p className="api-url-error">{topicsError}</p>}
+        </fieldset>
+      </div>
       <div className="sidebar-content">
         <fieldset>
           <legend>Choose Interface</legend>
@@ -187,14 +292,16 @@ const APICall: React.FC<APICallProps> = ({
           <legend>Choose Topic(s)</legend>
           <label>
             <select
+              className="topic-select"
               name="selectedTopics"
               multiple={true}
+              size={Math.min(Math.max(availableTopics.length, 4), 7)}
               value={selectedTopics}
               onChange={handleTopicChange}
             >
               {availableTopics.map((topic) => (
-                <option key={topic} value={topic}>
-                  {TOPICS[topic].label ?? topic}
+                <option key={topic.identifier} value={topic.identifier}>
+                  {topic.identifier}
                 </option>
               ))}
             </select>

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,3 +1,12 @@
+import { normalizeApiUrl } from '../utils/apiUrl';
+
+// Default API base URL (build-time value from the environment). The base must
+// include the version segment (e.g. ".../ga/v2") so that the appended endpoint
+// paths resolve correctly.
+export const DEFAULT_API_URL: string = normalizeApiUrl(
+  import.meta.env.VITE_API_URL,
+);
+
 // Supported interfaces
 export const INTERFACES = [
   'within',
@@ -5,15 +14,6 @@ export const INTERFACES = [
   'nearestNeighbour',
   'valuesAtPoint',
 ] as const;
-
-// Spatial tests used by topics
-export const DEFAULT_SPATIAL_TESTS = [
-  'within',
-  'intersect',
-  'nearestNeighbour',
-] as const;
-export const POINT_SPATIAL_TESTS = ['intersect', 'nearestNeighbour'] as const;
-export const RASTER_SPATIAL_TESTS = ['valuesAtPoint'] as const;
 
 // Interface shown on application start
 export const DEFAULT_INTERFACE = 'within';
@@ -40,56 +40,6 @@ export const INTERFACE_DEFAULT_PARAMETERS: Record<
   },
   valuesAtPoint: {},
 };
-
-// Topic-to-interface mapping and optional UI labels
-export const TOPICS: Record<string, { interfaces: string[]; label?: string }> =
-  {
-    land_f: { interfaces: [...DEFAULT_SPATIAL_TESTS], label: 'Land' },
-    kreis_f: { interfaces: [...DEFAULT_SPATIAL_TESTS], label: 'Kreis' },
-    gemeinde_f: { interfaces: [...DEFAULT_SPATIAL_TESTS], label: 'Gemeinde' },
-    gemarkung_f: { interfaces: [...DEFAULT_SPATIAL_TESTS], label: 'Gemarkung' },
-    flurstueck_f: {
-      interfaces: [...DEFAULT_SPATIAL_TESTS],
-      label: 'Flurstück',
-    },
-    schutzgebiet_f: {
-      interfaces: [...DEFAULT_SPATIAL_TESTS],
-      label: 'Schutzgebiet',
-    },
-    wasserschutzgebiet_f: {
-      interfaces: [...DEFAULT_SPATIAL_TESTS],
-      label: 'Wasserschutzgebiet',
-    },
-    natura2000_f: {
-      interfaces: [...DEFAULT_SPATIAL_TESTS],
-      label: 'Natura 2000 (Fläche)',
-    },
-    natura2000_p: {
-      interfaces: [...POINT_SPATIAL_TESTS],
-      label: 'Natura 2000 (Punkt)',
-    },
-    hohlraumbergaufsicht_f: {
-      interfaces: [...DEFAULT_SPATIAL_TESTS],
-      label: 'Hohlraum Bergaufsicht',
-    },
-    hohlraumunterirdisch_f: {
-      interfaces: [...DEFAULT_SPATIAL_TESTS],
-      label: 'Hohlraum Unterirdisch',
-    },
-    aspsperrzone_f: {
-      interfaces: [...DEFAULT_SPATIAL_TESTS],
-      label: 'Afrikanische Schweinepest Sperrzone',
-    },
-    adresse_p: {
-      interfaces: [...POINT_SPATIAL_TESTS],
-      label: 'Adresse (Punkt)',
-    },
-    hoehe_r: { interfaces: [...RASTER_SPATIAL_TESTS], label: 'Höhe' },
-    th_verwaltungseinheit_f: {
-      interfaces: [...DEFAULT_SPATIAL_TESTS],
-      label: 'Thüringer Verwaltungseinheit',
-    },
-  };
 
 // Initial map view
 export const INITIAL_POSITION: [number, number] = [51.009504, 13.806652];

--- a/src/utils/apiUrl.ts
+++ b/src/utils/apiUrl.ts
@@ -1,0 +1,6 @@
+// Strip trailing slashes so appending an endpoint path never produces a
+// double slash. Tolerates a missing value (env not set) by returning an
+// empty string instead of throwing.
+export function normalizeApiUrl(url: string | undefined): string {
+  return (url ?? '').trim().replace(/\/+$/, '');
+}

--- a/src/utils/topics.ts
+++ b/src/utils/topics.ts
@@ -1,0 +1,20 @@
+// A topic as used within the client UI.
+export type Topic = {
+  identifier: string; // value sent in the request "topics" field
+  interfaces: string[]; // spatial operations the topic supports
+};
+
+// Subset of the GA "/topics" response (TopicDefinitionOutsideDto).
+export type TopicDefinitionOutside = {
+  identifiers: string[];
+  supports?: string[];
+};
+
+// Map a GA topic definition to the client topic shape. The shortest identifier,
+// e.g. "kreis_f" out of ["sn_kreis_f", "kreis_f"]) is used.
+export function toTopic(raw: TopicDefinitionOutside): Topic {
+  const identifier = [...raw.identifiers].sort(
+    (a, b) => a.length - b.length,
+  )[0];
+  return { identifier, interfaces: raw.supports ?? [] };
+}


### PR DESCRIPTION
## Summary

- fetch topics from `{apiUrl}/topics` instead of a hardcoded list
- add editable API URL field (reload icon) overriding the build-time `VITE_API_URL` at runtime; ephemeral, resets on reload
- show fetch status via input border: yellow = unapplied, green = loaded, red = failed
- send the shortest identifier as the topic value
- remove hardcoded `TOPICS` and spatial-test constants from config
- make the topic multi-select larger by default and resizable